### PR TITLE
Provide a browser-alternative for xmlhttprequest

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,5 +53,8 @@
   "dependencies": {
     "es6-promise": "^3.1.2",
     "xmlhttprequest": "^1.8.0"
+  },
+  "browser": {
+    "xmlhttprequest": "./src/xmlhttprequest.js"
   }
 }

--- a/src/xmlhttprequest.js
+++ b/src/xmlhttprequest.js
@@ -1,0 +1,1 @@
+module.exports = XMLHttpRequest;


### PR DESCRIPTION
We need to specify a browser-alternative for twilio-common. See https://github.com/twilio/twilio-video.js/issues/28#issuecomment-271441280 for more info.