### PR TITLE
Fix broken Buffer import

### DIFF
--- a/lib/accessmanager.js
+++ b/lib/accessmanager.js
@@ -3,6 +3,7 @@
 var EventEmitter = require('events').EventEmitter;
 var inherits = require('util').inherits;
 var Promise = global.Promise || require('es6-promise').Promise;
+var Buffer = require('buffer/').Buffer;
 
 /**
  * Construct an {@link AccessManager} from an initial Access Token.

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "test": "gulp"
   },
   "dependencies": {
+    "buffer": "^5.0.6",
     "es6-promise": "^3.1.2",
     "xmlhttprequest": "^1.8.0"
   },


### PR DESCRIPTION
The current package breaks react-native for me, as Buffer needs to be explicitly imported in the accessmanager.js file.